### PR TITLE
Get Statement Types

### DIFF
--- a/include/jenic/parser/ast.h
+++ b/include/jenic/parser/ast.h
@@ -3,11 +3,13 @@
 
 #include <string>
 #include <vector>
+#include "jenic/parser/syntax/type.h"
 
 namespace jenic {
     class AbstractSyntaxNode {
 public:
 virtual ~AbstractSyntaxNode () {}
+virtual jenic::syntax::StatementType getStatementType () = 0;
 virtual std::string toString() = 0;
     };
     typedef std::vector<jenic::AbstractSyntaxNode*> AbstractSyntaxTree;

--- a/include/jenic/parser/syntax/function.h
+++ b/include/jenic/parser/syntax/function.h
@@ -17,6 +17,7 @@ namespace jenic {
             jenic::AbstractSyntaxTree body;
             Function(jenic::Token return_type, jenic::Token name, std::vector<std::pair<jenic::Token, jenic::Token>> args, jenic::AbstractSyntaxTree body);
             ~Function();
+            jenic::syntax::StatementType getStatementType ();
             std::string toString();
         };
     }

--- a/include/jenic/parser/syntax/return.h
+++ b/include/jenic/parser/syntax/return.h
@@ -10,6 +10,7 @@ namespace jenic {
             jenic::AbstractSyntaxNode* value;
             Return(jenic::AbstractSyntaxNode* value);
             ~Return();
+            jenic::syntax::StatementType getStatementType ();
             std::string toString();
         };
     }

--- a/include/jenic/parser/syntax/type.h
+++ b/include/jenic/parser/syntax/type.h
@@ -10,7 +10,8 @@ namespace jenic {
         enum class StatementType {
             STATEMENT_NULL,
             STATEMENT_FUNCTION,
-            STATEMENT_RETURN
+            STATEMENT_RETURN,
+            STATEMENT_VALUE
         };
         jenic::syntax::StatementType getType (std::vector<jenic::Token> tokens, int offset);
     }

--- a/include/jenic/parser/syntax/value.h
+++ b/include/jenic/parser/syntax/value.h
@@ -10,6 +10,7 @@ namespace jenic {
             public:
             jenic::Token value;
             Value(jenic::Token value);
+            jenic::syntax::StatementType getStatementType ();
             std::string toString();
         };
     }

--- a/lib/parser/syntax/function.cpp
+++ b/lib/parser/syntax/function.cpp
@@ -63,3 +63,7 @@ jenic::AbstractSyntaxNode* jenic::Parser::parseFunction(int * index) {
     * index = i;
     return new jenic::syntax::Function(return_type, name, args, body);
 }
+
+jenic::syntax::StatementType jenic::syntax::Function::getStatementType () {
+    return jenic::syntax::StatementType::STATEMENT_FUNCTION;
+}

--- a/lib/parser/syntax/return.cpp
+++ b/lib/parser/syntax/return.cpp
@@ -19,3 +19,7 @@ jenic::AbstractSyntaxNode* jenic::Parser::parseReturn(int* index) {
     * index = i;
     return new jenic::syntax::Return(value);
 }
+
+jenic::syntax::StatementType jenic::syntax::Return::getStatementType () {
+    return jenic::syntax::StatementType::STATEMENT_RETURN;
+}

--- a/lib/parser/syntax/value.cpp
+++ b/lib/parser/syntax/value.cpp
@@ -18,3 +18,7 @@ jenic::AbstractSyntaxNode* jenic::Parser::parseExpression(int* index) {
     std::cerr << "Error: unknown expression at offset " << i << std::endl;
     return new jenic::syntax::Value({.type = jenic::TOKEN_NULL});
 }
+
+jenic::syntax::StatementType jenic::syntax::Value::getStatementType () {
+    return jenic::syntax::StatementType::STATEMENT_VALUE;
+}


### PR DESCRIPTION
This change allows code to query the type of a statement, for example, to figure out how to compile it.