### PR TITLE
Group statements by type

### DIFF
--- a/include/jenic/collector/collector.h
+++ b/include/jenic/collector/collector.h
@@ -1,0 +1,29 @@
+#ifndef _JENIC_COLLECTOR_COLLECTOR_H
+#define _JENIC_COLLECTOR_COLLECTOR_H
+
+#include "jenic/parser/ast.h"
+
+namespace jenic {
+    class Collection {
+        public:
+        jenic::AbstractSyntaxTree variables;
+        jenic::AbstractSyntaxTree constants;
+        jenic::AbstractSyntaxTree functions;
+        Collection (jenic::AbstractSyntaxTree variables, jenic::AbstractSyntaxTree constants, jenic::AbstractSyntaxTree functions) {
+            this->variables = variables;
+            this->constants = constants;
+            this->functions = functions;
+        }
+    };
+    class Collector {
+        private:
+        jenic::AbstractSyntaxTree input;
+        public:
+        Collector(jenic::AbstractSyntaxTree input) {
+            this->input = input;
+        }
+        jenic::Collection collect ();
+    };
+}
+
+#endif

--- a/include/jenic/collector/collector.h
+++ b/include/jenic/collector/collector.h
@@ -9,10 +9,10 @@ namespace jenic {
         jenic::AbstractSyntaxTree variables;
         jenic::AbstractSyntaxTree constants;
         jenic::AbstractSyntaxTree functions;
-        Collection (jenic::AbstractSyntaxTree variables, jenic::AbstractSyntaxTree constants, jenic::AbstractSyntaxTree functions) {
-            this->variables = variables;
-            this->constants = constants;
-            this->functions = functions;
+        Collection (jenic::AbstractSyntaxTree variableTree, jenic::AbstractSyntaxTree constantTree, jenic::AbstractSyntaxTree functionTree) {
+            this->variables = variableTree;
+            this->constants = constantTree;
+            this->functions = functionTree;
         }
     };
     class Collector {
@@ -22,7 +22,7 @@ namespace jenic {
         Collector(jenic::AbstractSyntaxTree input) {
             this->input = input;
         }
-        jenic::Collection collect ();
+        jenic::Collection* collect ();
     };
 }
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(lexer)
 add_subdirectory(parser)
+add_subdirectory(collector)

--- a/lib/collector/CMakeLists.txt
+++ b/lib/collector/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(Collector STATIC collector.cpp)

--- a/lib/collector/collector.cpp
+++ b/lib/collector/collector.cpp
@@ -1,1 +1,21 @@
 #include "jenic/collector/collector.h"
+
+#include <iostream>
+
+jenic::Collection* jenic::Collector::collect () {
+    jenic::AbstractSyntaxTree variables;
+    jenic::AbstractSyntaxTree constants;
+    jenic::AbstractSyntaxTree functions;
+    for (int i = 0; i < input.size(); i ++) {
+        jenic::AbstractSyntaxNode* node = input [i];
+        switch (node->getStatementType()) {
+            case jenic::syntax::StatementType::STATEMENT_FUNCTION:
+            functions.push_back (node);
+            break;
+            default:
+            std::cerr << "Only functions, variables and constants may appear at the root scope";
+            break;
+        }
+    }
+   return new jenic::Collection (variables, constants, functions);
+}

--- a/lib/collector/collector.cpp
+++ b/lib/collector/collector.cpp
@@ -1,0 +1,1 @@
+#include "jenic/collector/collector.h"

--- a/tools/jenic/CMakeLists.txt
+++ b/tools/jenic/CMakeLists.txt
@@ -4,4 +4,4 @@ target_include_directories(jenic PUBLIC
 "${PROJECT_BINARY_DIR}"
 )
 
-target_link_libraries(jenic Lexer Parser)
+target_link_libraries(jenic Lexer Parser Collector)

--- a/tools/jenic/main.cpp
+++ b/tools/jenic/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "jenic/lexer/lexer.h"
 #include "jenic/parser/parser.h"
+#include "jenic/collector/collector.h"
 
 int main (int argc, char* argv []) {
     std::cout << "Jenic Version" << JENIC_MAJOR_VERSION << "." << JENIC_MINOR_VERSION << "." << JENIC_PATCH_VERSION << std::endl;
@@ -11,9 +12,20 @@ int main (int argc, char* argv []) {
     std::vector<jenic::Token> tokens = lexer.lex();
     jenic::Parser parser(tokens);
     jenic::AbstractSyntaxTree tree = parser.parse();
-    for (int i = 0; i < tree.size(); i ++) {
-        std::cout << tree [i]->toString() << std::endl;
-        delete tree [i];
+    jenic::Collector collector(tree);
+    jenic::Collection* collection = collector.collect();
+    for (int i = 0; i < collection->variables.size(); i ++) {
+        std::cout << collection->variables [i]->toString() << std::endl;
+        delete collection->variables [i];
     }
+    for (int i = 0; i < collection->constants.size(); i ++) {
+        std::cout << collection->constants [i]->toString() << std::endl;
+        delete collection->constants [i];
+    }
+    for (int i = 0; i < collection->functions.size(); i ++) {
+        std::cout << collection->functions[i]->toString() << std::endl;
+        delete collection->functions[i];
+    }
+    delete collection;
 return 0;
 }


### PR DESCRIPTION
This change makes the app create three groups of statements: variables (currently not used), constants (currently not used) and functions (only valid type on the root scope).
This new feature allows the app to detect when a statement in the root scope is not allowed to be there.