### PR TITLE
Variable references

### DIFF
--- a/include/jenic/parser/syntax/reference.h
+++ b/include/jenic/parser/syntax/reference.h
@@ -1,0 +1,25 @@
+#ifndef _JENIC_PARSER_SYNTAX_REFERENCE_H
+#define _JENIC_PARSER_SYNTAX_REFERENCE_H
+
+#include "jenic/parser/ast.h"
+#include "jenic/lexer/token.h"
+
+namespace jenic {
+    namespace syntax {
+        class Reference: public AbstractSyntaxNode {
+            public:
+            jenic::Token identifier;
+            Reference (jenic::Token identifier) {
+                this->identifier = identifier;
+            }
+            std::string toString () {
+                return identifier.value;
+            }
+            jenic::syntax::StatementType getStatementType () {
+                return jenic::syntax::StatementType::STATEMENT_REFERENCE;
+            }
+        }
+    }
+}
+
+#endif

--- a/include/jenic/parser/syntax/reference.h
+++ b/include/jenic/parser/syntax/reference.h
@@ -18,7 +18,7 @@ namespace jenic {
             jenic::syntax::StatementType getStatementType () {
                 return jenic::syntax::StatementType::STATEMENT_REFERENCE;
             }
-        }
+        };
     }
 }
 

--- a/include/jenic/parser/syntax/type.h
+++ b/include/jenic/parser/syntax/type.h
@@ -11,7 +11,8 @@ namespace jenic {
             STATEMENT_NULL,
             STATEMENT_FUNCTION,
             STATEMENT_RETURN,
-            STATEMENT_VALUE
+            STATEMENT_VALUE,
+            STATEMENT_REFERENCE
         };
         jenic::syntax::StatementType getType (std::vector<jenic::Token> tokens, int offset);
     }

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(Parser STATIC parser.cpp syntax/function.cpp syntax/type.cpp syntax/return.cpp syntax/value.cpp)
+add_library(Parser STATIC parser.cpp syntax/function.cpp syntax/type.cpp syntax/return.cpp syntax/value.cpp syntax/expression.cpp)
     

--- a/lib/parser/syntax/expression.cpp
+++ b/lib/parser/syntax/expression.cpp
@@ -1,5 +1,6 @@
 #include "jenic/parser/parser.h"
 #include "jenic/parser/syntax/value.h"
+#include "jenic/parser/syntax/reference.h"
 
 #include <iostream>
 
@@ -8,6 +9,10 @@ jenic::AbstractSyntaxNode* jenic::Parser::parseExpression(int* index) {
     if (tokens [i].type == jenic::TOKEN_NUMBER || tokens [i].type == jenic::TOKEN_STRING) {
         (*index)++;
         return new jenic::syntax::Value(tokens [i]);
+    }
+    if (tokens [i].type == jenic::TOKEN_IDENTIFIER) {
+        (*index) ++;
+        return new jenic::syntax::Reference(tokens [i]);
     }
     std::cerr << "Error: unknown expression at offset " << i << std::endl;
     return new jenic::syntax::Value({.type = jenic::TOKEN_NULL});

--- a/lib/parser/syntax/expression.cpp
+++ b/lib/parser/syntax/expression.cpp
@@ -1,0 +1,14 @@
+#include "jenic/parser/parser.h"
+#include "jenic/parser/syntax/value.h"
+
+#include <iostream>
+
+jenic::AbstractSyntaxNode* jenic::Parser::parseExpression(int* index) {
+    int i = * index;
+    if (tokens [i].type == jenic::TOKEN_NUMBER || tokens [i].type == jenic::TOKEN_STRING) {
+        (*index)++;
+        return new jenic::syntax::Value(tokens [i]);
+    }
+    std::cerr << "Error: unknown expression at offset " << i << std::endl;
+    return new jenic::syntax::Value({.type = jenic::TOKEN_NULL});
+}

--- a/lib/parser/syntax/value.cpp
+++ b/lib/parser/syntax/value.cpp
@@ -1,7 +1,4 @@
 #include "jenic/parser/syntax/value.h"
-#include "jenic/parser/parser.h"
-
-#include <iostream>
 
 jenic::syntax::Value::Value(jenic::Token value) {
     this->value = value;
@@ -9,16 +6,6 @@ jenic::syntax::Value::Value(jenic::Token value) {
 std::string jenic::syntax::Value::toString() {
     return value.value;
 }
-jenic::AbstractSyntaxNode* jenic::Parser::parseExpression(int* index) {
-    int i = * index;
-    if (tokens [i].type == jenic::TOKEN_NUMBER || tokens [i].type == jenic::TOKEN_STRING) {
-        (*index)++;
-        return new jenic::syntax::Value(tokens [i]);
-    }
-    std::cerr << "Error: unknown expression at offset " << i << std::endl;
-    return new jenic::syntax::Value({.type = jenic::TOKEN_NULL});
-}
-
 jenic::syntax::StatementType jenic::syntax::Value::getStatementType () {
     return jenic::syntax::StatementType::STATEMENT_VALUE;
 }


### PR DESCRIPTION
This change allows the parser to understand when the code references a variable (or constant).